### PR TITLE
fix(hasura): use same docker image in compose and k8s

### DIFF
--- a/kubernetes/hasura-deployment.yaml
+++ b/kubernetes/hasura-deployment.yaml
@@ -26,7 +26,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: ggoods-hasura-config
-          image: hasura/graphql-engine:v1.3.2.cli-migrations-v2
+          image: hasura/graphql-engine:v1.3.3.cli-migrations-v2
           imagePullPolicy: "IfNotPresent"
           name: "ggoods-hasura"
           ports:


### PR DESCRIPTION
there was a different version of hasura implemented in docker compose and in kubernetes 